### PR TITLE
Add NetBSD installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ A TUI feed reader for RSS, Atom, and (eventually) Podcasts. VIM keybindings. Ran
 cargo install moccasin
 ```
 
+### NetBSD
+
+If you are on NetBSD, a pre-compiled binary is available from the official repositories. To install it, simply run:
+
+```bash
+pkgin install moccasin
+```
+
+Or, if you prefer to build from source:
+```
+cd /usr/pkgsrc/news/moccasin
+make install
+```
+
 ## Usage
 
 Since "moccasin" is hard to spell and has too many letters, the executable is just called `mcsn`.


### PR DESCRIPTION
Hi,

I've just packaged `moccasin` for NetBSD and merged the package into the main branch.
Commit log, for reference: http://mail-index.netbsd.org/pkgsrc-changes/2023/09/03/msg281899.html

Please consider adding install instructions to the README.md

I got a few warnings building with Rust-1.71.1, leaving those here.

```
   Compiling moccasin v0.1.2 (/usr/pkgsrc/wip/moccasin/work/moccasin-0.1.2)
warning: unused import: `SortOrder`
 --> src/repo/storage.rs:1:29
  |
1 | use crate::config::{Config, SortOrder};
  |                             ^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `Item`
 --> src/repo/storage.rs:2:25
  |
2 | use crate::feed::{Feed, Item};
  |                         ^^^^

warning: unused variable: `red`
   --> src/config/theme.rs:133:13
    |
133 |         let red = make_color("#850908");
    |             ^^^ help: if this is intentional, prefix it with an underscore: `_red`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: unused variable: `fragment`
  --> src/ui/detail.rs:31:17
   |
31 |     fn from_dom(fragment: Dom) -> Self {
   |                 ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_fragment`

warning: enum `StorageRequest` is never used
  --> src/repo/repo.rs:23:6
   |
23 | enum StorageRequest {
   |      ^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: function `centered_rect_sized` is never used
   --> src/ui/mod.rs:217:4
    |
217 | fn centered_rect_sized(width: u16, height: u16, r: Rect) -> Rect {
    |    ^^^^^^^^^^^^^^^^^^^

warning: function `get_line_offset` is never used
 --> src/ui/detail.rs:7:4
  |
7 | fn get_line_offset(line_width: u16, text_area_width: u16, alignment: Alignment) -> u16 {
  |    ^^^^^^^^^^^^^^^

warning: struct `HTML` is never constructed
  --> src/ui/detail.rs:15:8
   |
15 | struct HTML<'a> {
   |        ^^^^

warning: associated items `from_dom`, `block`, `style`, `wrap`, `scroll`, and `alignment` are never used
  --> src/ui/detail.rs:31:8
   |
30 | impl<'a> HTML<'a> {
   | ----------------- associated items in this implementation
31 |     fn from_dom(fragment: Dom) -> Self {
   |        ^^^^^^^^
...
45 |     pub fn block(mut self, block: Block<'a>) -> HTML<'a> {
   |            ^^^^^
...
50 |     pub fn style(mut self, style: Style) -> HTML<'a> {
   |            ^^^^^
...
55 |     pub fn wrap(mut self, wrap: Wrap) -> HTML<'a> {
   |            ^^^^
...
60 |     pub fn scroll(mut self, offset: (u16, u16)) -> HTML<'a> {
   |            ^^^^^^
...
65 |     pub fn alignment(mut self, alignment: Alignment) -> HTML<'a> {
   |            ^^^^^^^^^

warning: unused `Result` that must be used
   --> src/app.rs:543:17
    |
543 |                 self.config.add_feed_url(&url);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
    = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
    |
543 |                 let _ = self.config.add_feed_url(&url);
    |                 +++++++

warning: unused `Result` that must be used
   --> src/app.rs:550:21
    |
550 |                     self.config.remove_feed_url(&url);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
help: use `let _ = ...` to ignore the resulting value
    |
550 |                     let _ = self.config.remove_feed_url(&url);
    |                     +++++++

warning: unused `Result` that must be used
   --> src/app.rs:551:21
    |
551 |                     self.repo.remove_feed_url(&url);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
help: use `let _ = ...` to ignore the resulting value
    |
551 |                     let _ = self.repo.remove_feed_url(&url);
    |                     +++++++

warning: unused `Result` that must be used
  --> src/repo/repo.rs:77:17
   |
77 |                 tx.send(RepositoryEvent::Refresh);
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this `Result` may be an `Err` variant, which should be handled
help: use `let _ = ...` to ignore the resulting value
   |
77 |                 let _ = tx.send(RepositoryEvent::Refresh);
   |                 +++++++

warning: unused `Result` that must be used
  --> src/repo/repo.rs:99:21
   |
99 |                     self.storage.write_all(&feeds);
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this `Result` may be an `Err` variant, which should be handled
help: use `let _ = ...` to ignore the resulting value
   |
99 |                     let _ = self.storage.write_all(&feeds);
   |                     +++++++

warning: unused `Result` that must be used
   --> src/repo/repo.rs:100:21
    |
100 |                     self.app_tx.send(RepositoryEvent::RetrievedAll(feeds));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
help: use `let _ = ...` to ignore the resulting value
    |
100 |                     let _ = self.app_tx.send(RepositoryEvent::RetrievedAll(feeds));
    |                     +++++++

warning: unused `Result` that must be used
   --> src/repo/repo.rs:104:21
    |
104 |                     self.storage.write_one(&feed);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
help: use `let _ = ...` to ignore the resulting value
    |
104 |                     let _ = self.storage.write_one(&feed);
    |                     +++++++

warning: unused `Result` that must be used
   --> src/repo/repo.rs:105:21
    |
105 |                     self.app_tx.send(RepositoryEvent::RetrievedOne(feed));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
help: use `let _ = ...` to ignore the resulting value
    |
105 |                     let _ = self.app_tx.send(RepositoryEvent::RetrievedOne(feed));
    |                     +++++++

warning: unused `Result` that must be used
   --> src/repo/repo.rs:126:13
    |
126 |             app_tx.send(RepositoryEvent::Aborted);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
help: use `let _ = ...` to ignore the resulting value
    |
126 |             let _ = app_tx.send(RepositoryEvent::Aborted);
    |             +++++++

warning: `moccasin` (lib) generated 18 warnings (run `cargo fix --lib -p moccasin` to apply 4 suggestions)
    Finished release [optimized] target(s) in 7m 27s
```

Thanks!